### PR TITLE
add node.js and babel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,56 @@ When the command is called, the callback is called with the arguments:
 * text: The command arguments
 
 
+Install
+-----------------------
+
+Clone the repo:
+
+```sh
+# clone without all of the history
+git clone --depth=1 https://github.com/oftn/oftn-bot.git my-bot-directory
+```
+
+If you want to build on ecmabot.js, copy sample-profile.js to ecmabot-profile.js and edit options. `nickserv` and `password` can be removed for development.
+
+To run the bot: `node ecmabot.js`.
+
+Currently the only way to update the bot is a full restart.
+
+### REPL
+
+ecmabot can run code in a sandbox. It uses [docker][docker], which you'll need to [install][docker-install]. If you don't install docker, the code execution will silently fail. 
+
+If docker is installed, it'll automatically download [js-eval][js-eval], which provides node, and node+babel for executing code. Each code snippet is run in a fresh container with limited memory, cpu usage, no network access, and a user that owns no files or has any special permissions ([see the docker run command][docker-opts]). Keep docker up to date in case any critical security vulnerabilities are found.
+
+To update the [js-eval][js-eval] version, run `docker pull brigand/js-eval`. This will get you the latest node stable and babel version. You don't need to restart the bot when you do this. The lazy way to do this:
+
+```sh
+# check for updates every 3 hours (a build occurs at least once every 12 hours)
+screen -dmS 'update-js-eval' bash -c 'while true; do sleep 10800; docker pull brigand/js-eval; done'
+```
+
+#### Examples
+
+node:
+
+```yaml
+user: n> require('path').join('foo', 'bar')
+bot: (okay) foo/bar
+```
+
+babel:
+
+```yaml
+user: b> const [foo, ...bar] = ['a', 'b', 'c'].entries(); bar
+bot: (okay) [ [ 1, 'b' ], [ 2, 'c' ] ]
+```
+
+[docker]: https://www.docker.com/
+[docker-install]: https://docs.docker.com/installation/
+[js-eval]: https://registry.hub.docker.com/u/brigand/js-eval/
+[docker-opts]: https://github.com/brigand/oftn-bot/blob/es6/lib/sandbox/index.js#L143
+
 Additional Documentation
 ------------------------
 

--- a/ecmabot.js
+++ b/ecmabot.js
@@ -16,7 +16,7 @@ var JSBot = function(profile) {
 	this.sandbox = new Sandbox(path.join(__dirname, "ecmabot-utils.js"));
 	this.factoids = new FactoidServer(path.join(__dirname, "ecmabot-factoids.json"));
 	this.caniuse_server = new CanIUseServer;
-	this.executeRegex = /^((?:sm|v8|js|>>?|\|)>)([^>].*)+/;
+	this.executeRegex = /^((?:sm?|v8|js?|b|n|>>?|>>>>|\|)>)([^>].*)+/;
 
 	Bot.call(this, profile);
 	this.set_log_level(this.LOG_ALL);
@@ -249,6 +249,12 @@ JSBot.prototype.caniuse = function(context, text) {
 	}
 };
 
-var profile = require("./ecmabot-profile.js");
+var profile;
+if (process.env.ECMABOT_PROFILE) {
+		profile = require(path.resolve(process.env.ECMABOT_PROFILE));
+} else {
+	profile = require("./ecmabot-profile.js");
+}
+
 (new JSBot(profile)).init();
 

--- a/lib/paste/gist.js
+++ b/lib/paste/gist.js
@@ -1,0 +1,69 @@
+var bhttp = require('bhttp');
+var util = require('util');
+var assign = require('object.assign');
+
+function log() {
+	console.error(util.format.apply(this, arguments));
+}
+
+/* createGist('some content', {
+	 filename: 'my name', description: 'something'
+	 })
+	 .then((url) => ...)
+	 */
+exports.createGist = function createSingleFileGist(text, _opts) {
+	var opts = assign({
+		filename: "misc.txt",
+		description: "unknown description"
+	}, _opts);
+
+	var body = {
+		description: opts.description,
+		files: {}
+	};
+
+	body.files[opts.filename] = {content: text};
+
+	log('Creating gist. filename: %j, length: %d', opts.filename, text.length);
+
+	return bhttp.post('https://api.github.com/gists', body, {
+			encodeJSON: true,
+			decodeJSON: true
+			})
+	.catch(function(e) {
+		log('Failed to create gist: %j', e);
+		throw e;
+	})
+	.then(function(res){
+		var url = res.body.html_url;
+		log('Created gist %j', url);
+
+		if (!url) {
+			var error = new Error('failed to create gist');
+			log('%s', error + "");
+			error.res = res;
+			throw error;
+		}
+
+		return exports.shorten(url).catch(function(err){
+			// fall back to returning the original url
+			return url;
+		});
+	});
+}
+
+exports.shorten = function shortenWithGitIo(url) {
+	return bhttp.post('https://git.io/', {url: url})
+		.then(function(res) {
+			var location = res.headers.location;
+			if (!location) {
+				log('Failed to shorten link: %d', res.statusCode);
+				log('  body: %j', res.body || null);
+				log('  headers: %j', res.headers);
+				throw new Error('No location found');
+			}
+
+			return location;
+		});
+}
+

--- a/lib/sandbox/index.js
+++ b/lib/sandbox/index.js
@@ -8,6 +8,8 @@ var Sandbox = module.exports = function(utils) {
 Sandbox.V8 = 1;
 Sandbox.SpiderMonkey = 2;
 Sandbox.Haskell = 3;
+Sandbox.Node = 4;
+Sandbox.Babel = 5;
 
 var SandboxError = function(name, message) {
 	return {
@@ -45,6 +47,10 @@ Sandbox.prototype.run = function(engine, timeout, code, hollaback, object) {
 			[this.utils],
 			{env: {LD_LIBRARY_PATH: "/usr/local/lib"}});
 		break;
+	case Sandbox.Node:
+		return this.runInJsEval('node', timeout, code, hollaback, object);
+	case Sandbox.Babel:
+		return this.runInJsEval('babel', timeout, code, hollaback, object);
 	}
 
 	// Any vars in da house?
@@ -91,14 +97,14 @@ Sandbox.prototype.runHaskell = function (timeout, code, hollaback, object) {
 	var stdout = ""
 	  , env = Object.create (process.env, {LANG: {value: "en_US.UTF-8", enumerable: true, writable: true, configurable: true}})
 	  , child = Spawn ("mueval",
-	                   ["--inferred-type", "--time-limit=" + Math.round(timeout / 1000)
-	                   ,"--no-imports", "--load-file=" + Path.join (__dirname, "hs", "Environment.hs")
-										 ,"--Extensions", "-e", code], {env: env});
+				["--inferred-type", "--time-limit=" + Math.round(timeout / 1000)
+				 ,"--no-imports", "--load-file=" + Path.join (__dirname, "hs", "Environment.hs")
+				 ,"--Extensions", "-e", code], {env: env});
 
-	child.stdout.on ("data", function (data) { if (data) stdout += data });
-	child.stderr.on ("data", function (data) { if (data) stdout += data }); // 2>&1
+	child.stdout.on("data", function (data) { if (data) stdout += data });
+	child.stderr.on("data", function (data) { if (data) stdout += data }); // 2>&1
 
-	child.on ("exit", function (code, signal) {
+	child.on("exit", function (code, signal) {
 		var lines = stdout.replace (/^\s+|\s+$/g, "").split ("\n");
 
 		if (code === 0) {
@@ -126,3 +132,56 @@ Sandbox.prototype.runHaskell = function (timeout, code, hollaback, object) {
 
 	child.stdin.end();
 };
+
+Sandbox.prototype.runInJsEval = function(engine, timeout, code, hollaback, object) {
+    // wrap code in an iife to get a sensible completion record
+    // otherwise we get e.g. 'use strict' when undefined is expected
+    code = '(function() { ' + code + ' }.call(global))';
+
+	var stdout = ""
+	  , childId = 'oftn_sandbox_' + Math.floor(0x10000000+Math.random()*0xefffffff).toString(32)
+	  , child = Spawn ("docker",
+	                   ["run", "-i", "--rm", "--net=none", "-m=64m", "-c=128", "--name=" + childId, "brigand/js-eval"], {env: process.env})
+	  , timeoutId = setTimeout(function() {
+	  		console.error("Timeout on docker container running this code: ", code);
+
+	  		Spawn ("docker", 
+	  			["kill", childId], {env: process.env})
+	  }, timeout);
+
+	child.stdout.on("data", function (data) { if (data) stdout += data });
+	child.stderr.pipe(process.stderr);
+
+	child.on("exit", function (code, signal) {
+		clearTimeout(timeoutId);
+		
+		if (code === 137) {
+			return hollaback.call(object, {
+				isJSEval: true,
+				reason: 'timeout, took over ' + timeout + 'ms'
+			});
+		} else if (code !== 0) {
+			console.error('Unknown js-eval error', code);
+			console.error(stdout);
+			return hollaback.call(object, {
+				isJSEval: true,
+				reason: 'unknown error'
+			});
+		}
+
+		var parsed = JSON.parse(stdout);
+
+		hollaback.call(object, {
+			isJSEval: true,
+			success: parsed.success,
+			text: parsed.text
+		});
+	});
+
+	child.stdin.write(JSON.stringify({
+		engine: engine,
+		code: code
+	}));
+
+	child.stdin.end();
+}

--- a/oftnbot.js
+++ b/oftnbot.js
@@ -50,7 +50,7 @@ var ΩF_0Bot = function(profile) {
 	
 	this.sandbox = new Sandbox(path.join(__dirname, "oftnbot-utils.js"));
 	this.factoids = new FactoidServer(path.join(__dirname, "oftnbot-factoids.json"));
-	this.executeRegex = /^((?:sm?|v8?|js?|hs?|>>?|>>>>|\|)>)([^>].*)+/;
+	this.executeRegex = /^((?:sm?|v8|hs?|js?|b|n|>>?|>>>>|\|)>)([^>].*)+/;
 
 	this.set_log_level(this.LOG_ALL);
 	this.set_trigger("!"); // Exclamation

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "repository": "https://github.com/oftn/oftn-bot",
   "dependencies": {
+    "bhttp": "^1.2.1",
+    "object.assign": "^4.0.3",
     "twitter": "~0.1.19"
   }
 }
-


### PR DESCRIPTION
Adds support for:

```
n> 5+5
node> 5+5

b> 5+5
babel> 5+5
```

These will fail if docker isn't installed.  Otherwise they will automatically download the image required to run these in a sandbox.  The command used:

```
"docker, ["run", 
// run in interactive mode, i.e. connect stdin to the process in the container's stdin
"-i", 
// don't keep the image running after it completes the execution
"--rm", 
// disallow all network access, like an unplugged computer with no wifi hardware
"--net=none", 
// limit to 64mb of RAM usage
"-m=64m", 
// 1024 means normal cpu priority, 128 means 'let other things interupt my usage at will'
"-c=128", 
// this name uses a random id, which is used to kill it after the timeout duration
"--name=" + childId, 
// the docker image to run, i.e. https://registry.hub.docker.com/u/brigand/js-eval/
// which builds from the repo https://github.com/brigand/docker-js-eval
"brigand/js-eval"]
```

